### PR TITLE
ci: Pull Request でレビューと lint を実行する

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Review and Lint
+name: Lint
 
 on:
   pull_request:
@@ -9,26 +9,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
-  review:
-    name: Review (reviewdog)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run reviewdog with golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_version: v2.11.4
-          reporter: github-pr-review
-          level: warning
-
   lint:
     name: Lint (golangci-lint)
     runs-on: ubuntu-latest

--- a/.github/workflows/review-and-lint.yml
+++ b/.github/workflows/review-and-lint.yml
@@ -18,17 +18,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache: true
+          fetch-depth: 0
 
       - name: Run reviewdog with golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          golangci_lint_version: v2.6
           reporter: github-pr-review
           level: warning
 
@@ -38,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -46,7 +45,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.6
           args: ./...

--- a/.github/workflows/review-and-lint.yml
+++ b/.github/workflows/review-and-lint.yml
@@ -1,0 +1,52 @@
+name: Review and Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: Review (reviewdog)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run reviewdog with golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          level: warning
+
+  lint:
+    name: Lint (golangci-lint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: ./...

--- a/.github/workflows/review-and-lint.yml
+++ b/.github/workflows/review-and-lint.yml
@@ -25,7 +25,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_version: v2.6
+          golangci_lint_version: v2.11.4
           reporter: github-pr-review
           level: warning
 
@@ -47,5 +47,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6
+          version: v2.11.4
           args: ./...

--- a/.github/workflows/review-and-lint.yml
+++ b/.github/workflows/review-and-lint.yml
@@ -48,4 +48,5 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.4
+          verify: false
           args: ./...

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,30 @@
+name: Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: Review (reviewdog)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run reviewdog with golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          golangci_lint_version: v2.11.4
+          reporter: github-pr-review
+          level: warning

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1234,7 +1234,7 @@ output:
     text:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.txt
+      path: stdout
       # Print linter name in the end of issue text.
       # Default: true
       print-linter-name: false
@@ -1248,12 +1248,12 @@ output:
     json:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.json
+      path: stdout
     # Prints issues in columns representation separated by tabulations.
     tab:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.txt
+      path: stdout
       # Print linter name in the end of issue text.
       # Default: true
       print-linter-name: true
@@ -1265,22 +1265,22 @@ output:
     html:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.html
+      path: stdout
     # Prints issues in the Checkstyle format.
     checkstyle:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.xml
+      path: stdout
     # Prints issues in the Code Climate format.
     code-climate:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.json
+      path: stdout
     # Prints issues in the JUnit XML format.
     junit-xml:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.xml
+      path: stdout
       # Support extra JUnit XML fields.
       # Default: false
       extended: true
@@ -1288,12 +1288,12 @@ output:
     teamcity:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.txt
+      path: stdout
     # Prints issues in the SARIF format.
     sarif:
       # Output path can be either `stdout`, `stderr` or path to the file to write to.
       # Default: stdout
-      path: ./path/to/output.json
+      path: stdout
 
   # Add a prefix to the output file references.
   # This option is ignored when using `output.path-mode: abs` mode.

--- a/report/feature-27.md
+++ b/report/feature-27.md
@@ -1,0 +1,25 @@
+# Issue #27: ci: Actions にレビューと linter の実行を追加する
+
+## 要件
+- GitHub Actions でレビューと linter の実行を追加する。
+- 実行タイミングは Pull Request の作成時と、追加コミット時。
+
+## 実装方針
+- `pull_request` イベントの `opened`, `synchronize`, `reopened` で起動する workflow を新規追加する。
+- レビューは `reviewdog/action-golangci-lint` を使い、PR にレビューコメントを返す。
+- lint は `golangci/golangci-lint-action` を使い、CI として成否を明示する。
+
+## 変更内容
+- `.github/workflows/review-and-lint.yml` を追加。
+  - `review` ジョブ:
+    - `actions/checkout@v4`
+    - `actions/setup-go@v5`
+    - `reviewdog/action-golangci-lint@v2`
+  - `lint` ジョブ:
+    - `actions/checkout@v4`
+    - `actions/setup-go@v5`
+    - `golangci/golangci-lint-action@v6`
+
+## 期待される効果
+- PR 作成時と更新時に、自動でレビューコメントと lint 結果が得られる。
+- レビュー体験と品質チェックの即時性を向上できる。


### PR DESCRIPTION
## 概要
- Pull Request の opened / reopened / synchronize で実行される workflow を追加
- review 用 workflow（review.yml）と lint 用 workflow（lint.yml）を分離
- reviewdog と golangci-lint の実行設定を追加
- .golangci.yaml の出力先を stdout に変更し、不要なローカル成果物生成を防止

## 動作確認
- make test
- make lint

Closes #27